### PR TITLE
fetch and cache

### DIFF
--- a/src/common/api/index.js
+++ b/src/common/api/index.js
@@ -1,0 +1,37 @@
+/**
+ * Model entities definitions
+ */
+export const Model = {
+  starship: { url: 'https://swapi.co/api/starships' }
+}
+
+const api = (model, callback) => {
+  fetch(model.url)
+    .then(results => results.json())
+    .then(data => {
+      let payload;
+
+      switch (model) {
+        case Model.starship:
+          payload = data
+            ? data.results.map((item, index) => ({
+              name: item.name,
+              id: index + 1,
+              url: item.url,
+              model: item.model,
+              manufacturer: item.manufacturer,
+              price: item.cost_in_credits,
+              max_speed: item.max_atmosphering_speed,
+              crew: item.crew,
+              passengers: item.passengers,
+              cargo: item.cargo_capacity
+            }))
+            : [];
+          break;
+      }
+
+      callback(payload)
+    })
+}
+
+export default api;

--- a/src/common/contexts/index.js
+++ b/src/common/contexts/index.js
@@ -6,7 +6,7 @@ const initialState = {
   planets: [],
   spaceships: [],
   vehicles: [],
-  loading: true
+  loading: false
 }
 
 const reducer = (state, action) => {
@@ -43,6 +43,8 @@ const reducer = (state, action) => {
 
 export const AppGlobalProvider = ({children}) => {
   const [state, dispatch] = useReducer(reducer, initialState);
+
+
 
   return (
     <GlobalContext.Provider value={{state, dispatch}}>

--- a/src/components/Spaceships.jsx
+++ b/src/components/Spaceships.jsx
@@ -1,41 +1,21 @@
-import React, {useEffect, useContext}  from 'react';
-import { useFetch } from '../hooks/fetch';
+import React, { useEffect, useContext }  from 'react';
+import api, { Model } from "../common/api";
 import Spaceshipcard from './Spaceshipcard';
-import {GlobalContext} from '../common/contexts';
+import { GlobalContext } from '../common/contexts';
 import { Link } from 'react-router-dom';
 
 import './Itemslist.scss';
 
+
 const Spaceships = props => {
   const {state: {spaceships, loading}, dispatch} = useContext(GlobalContext);
-  // const [isLoading, fetchedData] = useFetch('https://swapi.co/api/starships/', []);
 
   useEffect(() => {
-    dispatch({type: 'SET_LOADING'});
-
-    fetch('https://swapi.co/api/starships')
-    .then(results => results.json())
-    .then(data => {
-      const spaceshipsToSave = data
-        ? data.results.map((item, index) => ({
-            name: item.name,
-            id: index + 1,
-            url: item.url,
-            model: item.model,
-            manufacturer: item.manufacturer,
-            price: item.cost_in_credits,
-            max_speed: item.max_atmosphering_speed,
-            crew: item.crew,
-            passengers: item.passengers,
-            cargo: item.cargo_capacity
-          }))
-        : [];
-
-        dispatch({type: 'SET_SPACESHIPS', payload: spaceshipsToSave})
-    })
-
-  }, [dispatch])
-
+    if (!spaceships.length) {
+      dispatch({type: 'SET_LOADING'});
+      api(Model.starship, payload => dispatch({type: 'SET_SPACESHIPS', payload}));
+    }
+  }, [spaceships])
 
   let content = <p>Loading spaceships...</p>;
 


### PR DESCRIPTION
In this case we don't really need the _useFetch_ hook since it overlaps the scope and usage of global context. 
Instead, firstly we need to check whether de data is available, otherwise perform the request and keep the data cached, avoiding redundant requests.
Of course this is coarse and cache should have a limited lifespan, but I think this makes the point.
On the other hand, decoupling the fetch function helps performance (no more memory allocations con re-render) and reuse of code.